### PR TITLE
Add Jobaholic to Jobs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The Best Way to Totally Stress Out Your Team by Basecamp](https://basecamp.com/g
 - [RemoteFR](https://remotefr.com)
 - [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
 - [AI Dev Jobs](https://aidevboard.com) - AI and ML job board with public REST API. Aggregates roles from 55+ ATS sources including Greenhouse, Lever, and Ashby. Filter by remote/hybrid/onsite.
+- [Jobaholic](https://jobaholic.app) - AI job application automation. Aggregates remote roles across 8 ATS sources (Greenhouse, Lever, Workday, Ashby, Rippling, ADP MyJobs, Indeed, Phenom) and auto-fills the application form with a per-JD AI cover letter via Chrome extension. Free tier + Pro $25/month with 3-day trial.
 
 ## 🏡 Equipment
 


### PR DESCRIPTION
## What this adds

[Jobaholic](https://jobaholic.app), an AI job application automation platform that aggregates remote roles across 8 ATS sources and auto-fills the application form with a per-JD AI cover letter via a Chrome extension.

## Why it fits the Jobs section

Closest positioning match in the Jobs section is **AI Dev Jobs** (already listed), which describes itself as "AI and ML job board with public REST API. Aggregates roles from 55+ ATS sources including Greenhouse, Lever, and Ashby."

Jobaholic aggregates across 8 ATS sources (Greenhouse, Lever, Workday, Ashby, Rippling, ADP MyJobs, Indeed, Phenom) and adds the auto-fill + AI cover letter layer on top, so remote workers can apply at volume without typing the same 40-field form 30 times a week.

## Pricing

Free tier (job search + tracking). Pro \$25/month with 3-day no-card trial.

## Why no LinkedIn account-restriction risk

Unlike LazyApply, Sonara, and Massive which drive the LinkedIn Easy Apply UI through automation (LinkedIn account-restriction risk per User Agreement §8.2), Jobaholic operates on the company's own ATS form. No LinkedIn UI is touched.

Happy to adjust placement, wording, or remove if not a fit. Thanks for maintaining this list! 🙏