### PR TITLE
➕ Add Dopastep to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The Best Way to Totally Stress Out Your Team by Basecamp](https://basecamp.com/g
 - [Taskade - All-in-one organization & collaboration platform offering free upgrades during COVID-19](https://taskade.com/)
 - [Bubbles, show what you're talking about](https://www.usebubbles.com/)
 - [Work Adventure, meetups and virtual office as a 2D game](https://workadventu.re/)
+- [Dopastep, live focus rooms for body doubling with no camera and nothing to book](https://dopastep.com/)
 
 ## 🤖 Automation
 


### PR DESCRIPTION
Adds Dopastep to the Productivity section.

**Disclosure:** I built it, so please read this as a suggestion rather than a neutral recommendation — completely fine to close it if it is not a fit.

Why it may belong here: the section already has Work Adventure (virtual office) and Use Together (remote pair programming), and this is the same family — virtual co-working. Dopastep runs live focus rooms where people work alongside each other in synced 25-minute focus and 5-minute break rounds. There is no camera and no chat, which tends to be what remote workers who bounce off video-based tools are looking for, and there is nothing to book. It is free to use, and you can open a room and see the schedule without an account.

Body doubling / virtual co-working is not currently covered anywhere in the list.