### PR TITLE
📝 Add WeWorkFromHome to Jobs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ The Best Way to Totally Stress Out Your Team by Basecamp](https://basecamp.com/g
 - [AI Dev Jobs](https://aidevboard.com) - AI and ML job board with public REST API. Aggregates roles from 55+ ATS sources including Greenhouse, Lever, and Ashby. Filter by remote/hybrid/onsite.
 - [RemoteJobs.lat](https://remotejobs.lat) - Remote job board for Latin American tech professionals.
 - [Jobs in JS](https://jobsinjs.com/remote-javascript-jobs/) - Remote JavaScript jobs.
+- [WeWorkFromHome](https://weworkfromhome.com) - Remote job board aggregating listings daily from company Greenhouse, Lever, and Ashby boards.
 
 ## 🏡 Equipment
 


### PR DESCRIPTION
Adds [WeWorkFromHome](https://weworkfromhome.com) to the Jobs section - a remote job board that pulls listings daily from companies' own Greenhouse, Lever, and Ashby career pages. Free for job seekers.