### PR TITLE
Add Trippi to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The Best Way to Totally Stress Out Your Team by Basecamp](https://basecamp.com/g
 - [Remote Starter Kit by Hanno](https://www.remotestarterkit.com/)
 - [Gsuite: Extending Hangouts Meet premium features to all G Suite customers through July 1, 2020](https://gsuiteupdates.googleblog.com/2020/03/enabling-hangouts-meet-premium-features.html)
 - [Google Meet Grid View to show everyone in the Meet](https://chrome.google.com/webstore/detail/google-meet-grid-view/bjkegbgpfgpikgkfidhcihhiflbjgfic)
+- [Trippi, live translated subtitles for Google Meet, Zoom and Microsoft Teams — captures meeting audio and runs its own speech recognition instead of re-translating platform captions](https://gettrippi.app/)
 - [Microsoft's solution for COVID-19 is a free Teams subscription for six months
 ](https://www.pcworld.com/article/3530374/microsofts-solution-for-covid-19-is-a-free-teams-subscription-for-six-months.html)
 - [Slack, platform for team communication](https://slack.com/)


### PR DESCRIPTION
Trippi is a Chrome extension that adds live translated subtitles to Google Meet, Zoom (web) and Microsoft Teams (web). It captures the meeting audio and runs its own speech recognition/translation instead of re-translating the platform's own captions, so it also works where the platform offers no translation at all. Free to start, no meeting bot, nothing announced to other participants. Adding it next to the existing Google Meet Grid View entry in Productivity.