### PR TITLE
➕ Add Drawblins to digital events tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The Best Way to Totally Stress Out Your Team by Basecamp](https://basecamp.com/g
 - [flat.social - fun & playful virtual spaces](https://flat.social/)
 - [Kumospace, Make meaningful connections in unforgettable virtual spaces](https://www.kumospace.com/)
 - [Eventfinity, The Best All-In-One Hybrid Event Platform](https://www.eventfinity.co/)
+- [Drawblins, free party games for remote teams and company events](https://drawblins.com) - Seven games in one browser room (drawing, caption writing, trivia and more). Up to 30 people take turns while up to 500 watch live and still score by guessing in chat. No signup or install.
 
 ## 🧳 Jobs
 


### PR DESCRIPTION
Adds Drawblins to **🖥 Tools to set-up digital events**, alongside Gather, Work Adventure, SpatialChat and Trivvy.

[Drawblins](https://drawblins.com) is a free browser party-game site for remote teams. Seven games share one room, and it separates playing from spectating: up to 30 people take turns while up to 500 can be in the room watching live and scoring by guessing in chat. That split is what makes it usable for a large all-hands rather than only a small group.

Free, no signup, nothing to install.

Follows up on #143 — opening the PR directly since that is likely easier to review than a suggestion.

Disclosure: I built it.
