### PR TITLE
➕ Add RoleSense to Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ The Best Way to Totally Stress Out Your Team by Basecamp](https://basecamp.com/g
 - [AI Dev Jobs](https://aidevboard.com) - AI and ML job board with public REST API. Aggregates roles from 55+ ATS sources including Greenhouse, Lever, and Ashby. Filter by remote/hybrid/onsite.
 - [RemoteJobs.lat](https://remotejobs.lat) - Remote job board for Latin American tech professionals.
 - [Jobs in JS](https://jobsinjs.com/remote-javascript-jobs/) - Remote JavaScript jobs.
+- [RoleSense](https://role-sense.com) - Remote job board with per-role country eligibility and work-style signals (autonomy, pace, meetings) extracted from the posting text; sourced directly from ATS boards.
 
 ## 🏡 Equipment
 


### PR DESCRIPTION
Adds one entry under `Jobs` for RoleSense.

**What it does differently:** shows per-role country eligibility up front (most remote listings restrict where you can live but don't surface it per posting) and extracts work-style signals (autonomy, pace, meetings) from the posting text itself. Sourced directly from company ATS boards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)