### PR TITLE
Add Botik Discord meeting assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The Best Way to Totally Stress Out Your Team by Basecamp](https://basecamp.com/g
 
 ## 💪 Productivity
 - [Notah.ai - AI-powered meeting notes, transcription, and action items, an AI Executive Assistant](https://notah.ai)
+- [Botik](https://github.com/777genius/discord-meeting-assistant) - Self-hosted Discord meeting assistant that records voice calls, posts transcripts and summaries, and answers questions about the meeting.
 - [Remote Resources from collaborationsuperpowers: Everything you need to get started working remotely!](https://www.collaborationsuperpowers.com/remote-resources/)
 - [Edworking, One platform for you and your team](https://www.edworking.com)
 - [Use Together - Remote Pair Programming and Team Collaboration tool.](https://www.use-together.com/fr/)


### PR DESCRIPTION
Adds [Botik](https://github.com/777genius/discord-meeting-assistant), a self-hosted Discord meeting assistant that records voice calls, posts transcripts and summaries, and answers questions about the meeting.

- License: Apache-2.0
- First tagged release: [v1.0.0](https://github.com/777genius/discord-meeting-assistant/releases/tag/v1.0.0)
- I am the author of the project.

Made with [Cursor](https://cursor.com)